### PR TITLE
Fixes quote rendering with empty lines

### DIFF
--- a/Pacos.Tests.Unit/TelegramMarkdownRendererTests.cs
+++ b/Pacos.Tests.Unit/TelegramMarkdownRendererTests.cs
@@ -12,6 +12,14 @@ internal sealed class TelegramMarkdownRendererTests
         .UseMdExtensions()
         .Build();
 
+    private static readonly VerifySettings VerifySettings = new();
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        // VerifySettings.DisableDiff();
+    }
+
     [Test]
     public void Render_WhenDocumentIsEmpty_ShouldReturnEmptyString()
     {
@@ -42,7 +50,7 @@ internal sealed class TelegramMarkdownRendererTests
         var standardMarkdownDoc = Markdown.Parse(standardMarkdown, MarkdownPipeline);
         var actualTelegramMarkdown = new TelegramMarkdownRenderer().Render(standardMarkdownDoc);
 
-        await Verify(actualTelegramMarkdown);
+        await Verify(actualTelegramMarkdown, VerifySettings);
     }
 
     [Test]
@@ -53,7 +61,7 @@ internal sealed class TelegramMarkdownRendererTests
         var standardMarkdownDoc = Markdown.Parse(standardMarkdown, MarkdownPipeline);
         var actualTelegramMarkdown = new TelegramMarkdownRenderer().Render(standardMarkdownDoc);
 
-        await Verify(actualTelegramMarkdown);
+        await Verify(actualTelegramMarkdown, VerifySettings);
     }
 
     [Test]
@@ -64,7 +72,7 @@ internal sealed class TelegramMarkdownRendererTests
         var standardMarkdownDoc = Markdown.Parse(standardMarkdown, MarkdownPipeline);
         var actualTelegramMarkdown = new TelegramMarkdownRenderer().Render(standardMarkdownDoc);
 
-        await Verify(actualTelegramMarkdown);
+        await Verify(actualTelegramMarkdown, VerifySettings);
     }
 
     [Test]
@@ -75,7 +83,7 @@ internal sealed class TelegramMarkdownRendererTests
         var standardMarkdownDoc = Markdown.Parse(standardMarkdown, MarkdownPipeline);
         var actualTelegramMarkdown = new TelegramMarkdownRenderer().Render(standardMarkdownDoc);
 
-        await Verify(actualTelegramMarkdown);
+        await Verify(actualTelegramMarkdown, VerifySettings);
     }
 
     [Test]
@@ -86,6 +94,6 @@ internal sealed class TelegramMarkdownRendererTests
         var standardMarkdownDoc = Markdown.Parse(standardMarkdown, MarkdownPipeline);
         var actualTelegramMarkdown = new TelegramMarkdownRenderer().Render(standardMarkdownDoc);
 
-        await Verify(actualTelegramMarkdown);
+        await Verify(actualTelegramMarkdown, VerifySettings);
     }
 }

--- a/Pacos/Services/TelegramMarkdownRenderer.cs
+++ b/Pacos/Services/TelegramMarkdownRenderer.cs
@@ -281,7 +281,7 @@ public sealed class TelegramMarkdownRenderer
 
                 // Split the content by lines and add > prefix to each
                 string paraContent = paraRenderer._output.ToString().Trim();
-                string[] lines = paraContent.Split('\n', StringSplitOptions.None);
+                string[] lines = paraContent.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries);
                 foreach (string line in lines)
                 {
                     _output.AppendLine(">" + line);
@@ -293,7 +293,7 @@ public sealed class TelegramMarkdownRenderer
                 var blockRenderer = new TelegramMarkdownRenderer();
                 blockRenderer.RenderBlock(block);
                 string blockContent = blockRenderer._output.ToString();
-                string[] lines = blockContent.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+                string[] lines = blockContent.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries);
                 foreach (string line in lines)
                 {
                     _output.AppendLine(">" + line);


### PR DESCRIPTION
Ensures correct rendering of quotes by handling empty lines
introduced by different newline characters (\r, \n).

Also, applies VerifySettings to TelegramMarkdownRendererTests for consistent test results.
