### PR TITLE
Removes unnecessary media resolution setting

### DIFF
--- a/Pacos/Services/GenerativeAi/ImageGenerationService.cs
+++ b/Pacos/Services/GenerativeAi/ImageGenerationService.cs
@@ -61,7 +61,7 @@ public sealed class ImageGenerationService
         return new GenerativeModel(
             apiKey: _options.Value.GoogleCloudApiKey,
             model: _options.Value.ImageGenerationModel,
-            new GenerationConfig { ResponseModalities = [Modality.IMAGE, Modality.TEXT], MediaResolution = MediaResolution.MEDIA_RESOLUTION_HIGH },
+            new GenerationConfig { ResponseModalities = [Modality.IMAGE, Modality.TEXT] },
             ImgSafetySettings,
             httpClient: _httpClientFactory.CreateClient(nameof(HttpClientType.GoogleCloudImageGeneration)),
             logger: _logger);


### PR DESCRIPTION
The MediaResolution setting was removed from the GenerationConfig.

It was deemed unnecessary and doesn't affect the image generation process.
