### PR TITLE
Removes caching directives from Docker build

### DIFF
--- a/.github/workflows/build_and_push.yml
+++ b/.github/workflows/build_and_push.yml
@@ -53,8 +53,6 @@ jobs:
           push: true
           context: .
           file: ./${{ env.MAIN_PROJECT_DIR }}/Dockerfile
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
           tags: |
             ${{ vars.DOCKER_REGISTRY }}/${{ vars.DOCKER_IMAGE }}:${{ inputs.tag }}
           platforms: |


### PR DESCRIPTION
Removes the `cache-from` and `cache-to` directives from the Docker build process in the GitHub Actions workflow.
