### PR TITLE
Do not download a file if it's > 20 MB (fixes #11)

### DIFF
--- a/Pacos/Models/TelegramFileMetadata.cs
+++ b/Pacos/Models/TelegramFileMetadata.cs
@@ -1,0 +1,3 @@
+﻿namespace Pacos.Models;
+
+public record TelegramFileMetadata(string FileId, string MimeType, long? FileSize);


### PR DESCRIPTION
Refactors media handling to include file size limits and error
messages. It introduces a `TelegramFileMetadata` record for
better data encapsulation. Adds file size validation to prevent
large downloads, and provides more informative error messages to the
user when media download fails. Also, it selects the largest photo
from the available photos in a message.
