### PR TITLE
Moves extension method to correct location

### DIFF
--- a/Pacos/Extensions/GenerativeAiChatClientExtensions.cs
+++ b/Pacos/Extensions/GenerativeAiChatClientExtensions.cs
@@ -2,9 +2,9 @@
 using GenerativeAI;
 using GenerativeAI.Microsoft;
 
-namespace Pacos.Utils;
+namespace Pacos.Extensions;
 
-public static class GeminiClientHackTools
+public static class GenerativeAiChatClientExtensions
 {
     public static void ReplaceModel(
         this GenerativeAIChatClient chatClient,

--- a/Pacos/Program.cs
+++ b/Pacos/Program.cs
@@ -10,13 +10,13 @@ using NLog.Extensions.Logging;
 using NTextCat;
 using Pacos.Constants;
 using Pacos.Enums;
+using Pacos.Extensions;
 using Pacos.Models.Options;
 using Pacos.Services;
 using Pacos.Services.BackgroundTasks;
 using Pacos.Services.ChatCommandHandlers;
 using Pacos.Services.GenerativeAi;
 using Pacos.Services.Markdown;
-using Pacos.Utils;
 using Telegram.Bot;
 using LogLevel = Microsoft.Extensions.Logging.LogLevel;
 
@@ -132,6 +132,7 @@ public sealed class Program
                             AutoCallFunction = true,
                         };
 
+                        // GenerativeAIChatClient recreates GenerativeModel, so we have to use a hack to set the model
                         chatClientObj.ReplaceModel(chatGenerativeModel, s.GetRequiredService<ILogger<IChatClient>>());
 
                         return chatClientObj;


### PR DESCRIPTION
Moves the extension method for replacing the model in GenerativeAIChatClient to a more appropriate location, and renames the class to reflect its purpose as an extension for the GenerativeAIChatClient.
