### PR TITLE
Updates options validation rules

### DIFF
--- a/Pacos/Models/Options/PacosOptions.cs
+++ b/Pacos/Models/Options/PacosOptions.cs
@@ -16,21 +16,14 @@ public sealed class PacosOptions
     public required long[] AllowedChatIds { get; set; }
 
     [Required]
-    [MinLength(1)]
-    public required string[] AllowedLanguageCodes { get; set; }
-
-    [Required]
     public required string ChatModel { get; set; }
 
     [Required]
     public required string ImageGenerationModel { get; set; }
 
-    [Required]
-    public required string WebProxy { get; set; }
+    public required string? WebProxy { get; set; }
 
-    [Required]
-    public required string WebProxyLogin { get; set; }
+    public required string? WebProxyLogin { get; set; }
 
-    [Required]
-    public required string WebProxyPassword { get; set; }
+    public required string? WebProxyPassword { get; set; }
 }


### PR DESCRIPTION
Relax requirements for certain configuration options related to proxies and language codes.

This change makes the `AllowedLanguageCodes`, `WebProxy`, `WebProxyLogin`, and `WebProxyPassword` configuration options no longer required.