### PR TITLE
Enables property modification after initialization

### DIFF
--- a/Pacos/Models/McpServer.cs
+++ b/Pacos/Models/McpServer.cs
@@ -6,26 +6,26 @@ namespace Pacos.Models;
 public sealed class McpServer
 {
     [JsonPropertyName("type")]
-    public ServerType Type { get; init; }
+    public ServerType Type { get; set; }
 
     [JsonIgnore]
     public string? Name { get; set; }
 
     [JsonPropertyName("command")]
-    public string? Command { get; init; }
+    public string? Command { get; set; }
 
     [JsonPropertyName("args")]
-    public string[] Args { get; init; } = [];
+    public string[] Args { get; set; } = [];
 
     [JsonPropertyName("env")]
-    public Dictionary<string, string?> Env { get; init; } = new();
+    public Dictionary<string, string?> Env { get; set; } = new();
 
     [JsonPropertyName("envFile")]
-    public string? EnvFile { get; init; }
+    public string? EnvFile { get; set; }
 
     [JsonPropertyName("url")]
-    public string? Url { get; init; }
+    public string? Url { get; set; }
 
     [JsonPropertyName("headers")]
-    public Dictionary<string, string> Headers { get; init; } = new();
+    public Dictionary<string, string> Headers { get; set; } = new();
 }

--- a/Pacos/Models/Options/PacosOptions.cs
+++ b/Pacos/Models/Options/PacosOptions.cs
@@ -6,7 +6,7 @@ public sealed class PacosOptions
 {
     [Required]
     [RegularExpression(".*:.*")]
-    public required string TelegramBotApiKey { get; init; }
+    public required string TelegramBotApiKey { get; set; }
 
     [Required]
     public required string GoogleCloudApiKey { get; set; }


### PR DESCRIPTION
Allows modification of properties in `McpServer` and `PacosOptions` models after initialization.

This change replaces `init` accessors with `set` accessors, enabling the values of these properties to be modified after the object is initially created. This is required to load the configurations after instantiating the objects.
