### PR TITLE
Improves resilience of API calls

### DIFF
--- a/Pacos/Services/ChatCommandHandlers/MentionHandler.cs
+++ b/Pacos/Services/ChatCommandHandlers/MentionHandler.cs
@@ -109,7 +109,7 @@ public sealed class MentionHandler
     {
         var result = await Policy
             .Handle<ApiException>(x => x.ErrorCode is 502 or 503 or 504
-                                       || x.ErrorMessage.Contains("try again", StringComparison.OrdinalIgnoreCase))
+                                       || x.ErrorMessage?.Contains("try again", StringComparison.OrdinalIgnoreCase) == true)
             .Or<HttpRequestException>()
             .WaitAndRetryAsync(retryCount: 2, retryNumber => TimeSpan.FromMilliseconds(retryNumber * 200))
             .ExecuteAndCaptureAsync(async () => await _chatService.GetResponseAsync(

--- a/Pacos/Services/ChatCommandHandlers/MentionHandler.cs
+++ b/Pacos/Services/ChatCommandHandlers/MentionHandler.cs
@@ -108,8 +108,8 @@ public sealed class MentionHandler
         string? fileMimeType = null)
     {
         var result = await Policy
-            .Handle<Exception>()
-            .Or<ApiException>()
+            .Handle<ApiException>(x => x.ErrorCode is 502 or 503 or 504
+                                       || x.ErrorMessage.Contains("try again", StringComparison.OrdinalIgnoreCase))
             .Or<HttpRequestException>()
             .WaitAndRetryAsync(retryCount: 2, retryNumber => TimeSpan.FromMilliseconds(retryNumber * 200))
             .ExecuteAndCaptureAsync(async () => await _chatService.GetResponseAsync(


### PR DESCRIPTION
Refines the retry policy for API calls to specifically handle
`ApiException` with error codes 502, 503, and 504, or when the
error message contains "try again". This enhances the application's
ability to recover from temporary server-side issues and transient
network problems, thus improving overall stability.
