### PR TITLE
Prevents upscaling smaller videos

### DIFF
--- a/Pacos/Services/VideoConversion/VideoConverter.cs
+++ b/Pacos/Services/VideoConversion/VideoConverter.cs
@@ -41,8 +41,21 @@ public class VideoConverter
             var ratioX = (double)maxWidth / videoStream.Width;
             var ratioY = (double)maxHeight / videoStream.Height;
             var ratio = Math.Min(ratioX, ratioY);
-            var newWidth = (int)(videoStream.Width * ratio);
-            var newHeight = (int)(videoStream.Height * ratio);
+
+            // Don't upscale video if it's already smaller than maximum dimensions
+            int newWidth, newHeight;
+            if (ratio > 1.0)
+            {
+                // Use original dimensions since video is already smaller than maximum
+                newWidth = videoStream.Width;
+                newHeight = videoStream.Height;
+            }
+            else
+            {
+                // Downscale video to maximum dimensions
+                newWidth = (int)(videoStream.Width * ratio);
+                newHeight = (int)(videoStream.Height * ratio);
+            }
 
             if (newWidth % 2 != 0) newWidth--;
             if (newHeight % 2 != 0) newHeight--;


### PR DESCRIPTION
Modifies video conversion to avoid upscaling videos if their dimensions are already smaller than the specified maximum dimensions.
This change ensures that the original video quality is preserved for smaller videos, rather than artificially increasing their size and potentially introducing artifacts.
