### PR TITLE
Improves retry logic to handle empty responses from the chat service

### DIFF
--- a/Pacos/Models/ChatResponseInfo.cs
+++ b/Pacos/Models/ChatResponseInfo.cs
@@ -1,0 +1,5 @@
+﻿using Microsoft.Extensions.AI;
+
+namespace Pacos.Models;
+
+public sealed record ChatResponseInfo(string Text, IReadOnlyCollection<DataContent> DataContents);

--- a/Pacos/Services/GenerativeAi/ChatService.cs
+++ b/Pacos/Services/GenerativeAi/ChatService.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using System.Globalization;
 using Microsoft.Extensions.AI;
 using Pacos.Constants;
+using Pacos.Models;
 
 namespace Pacos.Services.GenerativeAi;
 
@@ -50,7 +51,7 @@ public sealed class ChatService : IDisposable
         return _chatSemaphores.GetOrAdd(chatId, _ => new SemaphoreSlim(initialCount: 1, maxCount: 1));
     }
 
-    public async Task<(string Text, IReadOnlyCollection<DataContent> DataContents)> GetResponseAsync(
+    public async Task<ChatResponseInfo> GetResponseAsync(
         long chatId,
         long messageId,
         string authorName,
@@ -148,7 +149,7 @@ public sealed class ChatService : IDisposable
                 responseText = "♿ " + responseText;
             }
 
-            return (responseText, dataContents);
+            return new ChatResponseInfo(responseText, dataContents);
         }
         finally
         {


### PR DESCRIPTION
Updates the chat service and mention handler to use a dedicated
`ChatResponseInfo` record for encapsulating chat responses,
including text and data contents.
