### PR TITLE
Filters empty or whitespace-only banned words

### DIFF
--- a/Pacos/Services/WordFilter.cs
+++ b/Pacos/Services/WordFilter.cs
@@ -6,7 +6,7 @@ public sealed class WordFilter
 
     public WordFilter(string[] bannedWords)
     {
-        _bannedWords = bannedWords;
+        _bannedWords = bannedWords.Where(x => !string.IsNullOrWhiteSpace(x)).ToArray();
     }
 
     public bool ContainsBannedWords(string message)


### PR DESCRIPTION
Ensures that the word filter does not include empty or whitespace-only strings in the list of banned words, preventing potential issues during filtering.
