### PR TITLE
Renames and adds string extension methods

### DIFF
--- a/Pacos.Tests.Unit/StringExtensionsTests.cs
+++ b/Pacos.Tests.Unit/StringExtensionsTests.cs
@@ -7,10 +7,10 @@ namespace Pacos.Tests.Unit;
 internal sealed class StringExtensionsTests
 {
     [Test]
-    public void TryLeft_WhenNull_ShouldReturnNull()
+    public void TakeLeft_WhenNull_ShouldReturnNull()
     {
         const string? source = null;
-        var result = source.TryLeft(1);
+        var result = source.TakeLeft(1);
         Assert.That(result, Is.Null);
     }
 
@@ -26,24 +26,24 @@ internal sealed class StringExtensionsTests
     [TestCase("abc", 3, "abc")]
     [TestCase("abc", 4, "abc")]
     [TestCase("abc", 999, "abc")]
-    public void TryLeft_WhenArgumentsValid_ShouldReturnExpectedResult(string source, int maxLength, string expectedResult)
+    public void TakeLeft_WhenArgumentsValid_ShouldReturnExpectedResult(string source, int maxLength, string expectedResult)
     {
-        var actualResult = source.TryLeft(maxLength);
+        var actualResult = source.TakeLeft(maxLength);
         Assert.That(actualResult, Is.EqualTo(expectedResult));
     }
 
     [TestCase("", -1)]
     [TestCase("a", -2)]
-    public void TryLeft_WhenMaxLengthIsLessThanZero_ShouldThrowArgumentOutOfRangeException(string source, int maxLength)
+    public void TakeLeft_WhenMaxLengthIsLessThanZero_ShouldThrowArgumentOutOfRangeException(string source, int maxLength)
     {
-        Assert.Throws<ArgumentOutOfRangeException>(() => _ = source.TryLeft(maxLength));
+        Assert.Throws<ArgumentOutOfRangeException>(() => _ = source.TakeLeft(maxLength));
     }
 
     [Test]
-    public void TryRight_WhenNull_ShouldReturnNull()
+    public void TakeRight_WhenNull_ShouldReturnNull()
     {
         const string? source = null;
-        var result = source.TryRight(1);
+        var result = source.TakeRight(1);
         Assert.That(result, Is.Null);
     }
 
@@ -59,17 +59,17 @@ internal sealed class StringExtensionsTests
     [TestCase("abc", 3, "abc")]
     [TestCase("abc", 4, "abc")]
     [TestCase("abc", 999, "abc")]
-    public void TryRight_WhenArgumentsValid_ShouldReturnExpectedResult(string source, int maxLength, string expectedResult)
+    public void TakeRight_WhenArgumentsValid_ShouldReturnExpectedResult(string source, int maxLength, string expectedResult)
     {
-        var actualResult = source.TryRight(maxLength);
+        var actualResult = source.TakeRight(maxLength);
         Assert.That(actualResult, Is.EqualTo(expectedResult));
     }
 
     [TestCase("", -1)]
     [TestCase("a", -2)]
-    public void TryRight_WhenMaxLengthIsLessThanZero_ShouldThrowArgumentOutOfRangeException(string source, int maxLength)
+    public void TakeRight_WhenMaxLengthIsLessThanZero_ShouldThrowArgumentOutOfRangeException(string source, int maxLength)
     {
-        Assert.Throws<ArgumentOutOfRangeException>(() => _ = source.TryRight(maxLength));
+        Assert.Throws<ArgumentOutOfRangeException>(() => _ = source.TakeRight(maxLength));
     }
 
     [TestCase(null, null, true)]
@@ -105,6 +105,25 @@ internal sealed class StringExtensionsTests
     }
 
     [Test]
+    public void IsNullOrEmpty_WhenNull_ShouldReturnTrue()
+    {
+        const string? value = null;
+        Assert.That(value.IsNullOrEmpty(), Is.True);
+    }
+
+    [Test]
+    public void IsNullOrEmpty_WhenEmpty_ShouldReturnTrue()
+    {
+        Assert.That(string.Empty.IsNullOrEmpty(), Is.True);
+    }
+
+    [Test]
+    public void IsNullOrEmpty_WhenNonEmpty_ShouldReturnFalse()
+    {
+        Assert.That("test".IsNullOrEmpty(), Is.False);
+    }
+
+    [Test]
     public void Cut_WhenNull_ShouldReturnNull()
     {
         const string? source = null;
@@ -121,17 +140,17 @@ internal sealed class StringExtensionsTests
     [TestCase("1234", 4, "1234")] // Length == text length
     [TestCase("12345", 4, "1...")] // Length < text length, length = 4
     [TestCase("1234", 3, "...")] // Length < text length, length = 3
-    public void Cut_WhenTextLengthNotExceedsLengthOrLengthIs3_ShouldReturnExpected(string source, int length, string expected)
+    public void Cut_WhenTextLengthNotExceedsLengthOrLengthIs3_ShouldReturnExpected(string source, int maxLength, string expected)
     {
-        var result = source.Cut(length);
+        var result = source.Cut(maxLength);
         Assert.That(result, Is.EqualTo(expected));
     }
 
     [TestCase("abc", 0)]
     [TestCase("abc", 1)]
     [TestCase("abc", 2)]
-    public void Cut_WhenLengthIsLessThan3_ShouldThrowArgumentOutOfRangeException(string source, int length)
+    public void Cut_WhenLengthIsLessThan3_ShouldThrowArgumentOutOfRangeException(string source, int maxLength)
     {
-        Assert.Throws<ArgumentOutOfRangeException>(() => _ = source.Cut(length));
+        Assert.Throws<ArgumentOutOfRangeException>(() => _ = source.Cut(maxLength));
     }
 }

--- a/Pacos/Extensions/StringExtensions.cs
+++ b/Pacos/Extensions/StringExtensions.cs
@@ -9,28 +9,39 @@ namespace Pacos.Extensions;
 public static class StringExtensions
 {
     /// <summary>
+    /// Checks if the string is not null or empty.
+    /// </summary>
+    /// <param name="text">source string</param>
+    /// <returns>True if the string is not null or empty, false otherwise.</returns>
+    [Pure]
+    public static bool IsNotNullOrEmpty([NotNullWhen(true)] this string? text)
+    {
+        return !string.IsNullOrEmpty(text);
+    }
+
+    /// <summary>
     /// Checks if the string is null or empty.
     /// </summary>
-    /// <param name="src">source string</param>
+    /// <param name="text">source string</param>
     /// <returns>True if the string is null or empty, false otherwise.</returns>
     [Pure]
-    public static bool IsNotNullOrEmpty(this string? src)
+    public static bool IsNullOrEmpty([NotNullWhen(false)] this string? text)
     {
-        return !string.IsNullOrEmpty(src);
+        return string.IsNullOrEmpty(text);
     }
 
     /// <summary>
     /// Returns the leftmost maxLength characters from the string.
     /// </summary>
-    /// <param name="src">source string</param>
+    /// <param name="text">source string</param>
     /// <param name="maxLength">maximum length of the string</param>
     /// <returns>Leftmost maxLength characters from the string.</returns>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when maxLength is less than 0.</exception>
     [Pure]
-    [return: NotNullIfNotNull(nameof(src))]
-    public static string? TryLeft(this string? src, int maxLength)
+    [return: NotNullIfNotNull(nameof(text))]
+    public static string? TakeLeft(this string? text, int maxLength)
     {
-        if (src is null)
+        if (text is null)
         {
             return null;
         }
@@ -39,22 +50,22 @@ public static class StringExtensions
         {
             0 => string.Empty,
             < 0 => throw new ArgumentOutOfRangeException(nameof(maxLength), $"{nameof(maxLength)} must be greater than 0"),
-            _ => src.Length <= maxLength ? src : src[..maxLength],
+            _ => text.Length <= maxLength ? text : text[..maxLength],
         };
     }
 
     /// <summary>
     /// Returns the rightmost maxLength characters from the string.
     /// </summary>
-    /// <param name="src">source string</param>
+    /// <param name="text">source string</param>
     /// <param name="maxLength">maximum length of the string</param>
     /// <returns>Rightmost maxLength characters from the string.</returns>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when maxLength is less than 0.</exception>
     [Pure]
-    [return: NotNullIfNotNull(nameof(src))]
-    public static string? TryRight(this string? src, int maxLength)
+    [return: NotNullIfNotNull(nameof(text))]
+    public static string? TakeRight(this string? text, int maxLength)
     {
-        if (src is null)
+        if (text is null)
         {
             return null;
         }
@@ -63,29 +74,35 @@ public static class StringExtensions
         {
             0 => string.Empty,
             < 0 => throw new ArgumentOutOfRangeException(nameof(maxLength), $"{nameof(maxLength)} must be greater than 0"),
-            _ => src.Length <= maxLength ? src : src[^maxLength..],
+            _ => text.Length <= maxLength ? text : text[^maxLength..],
         };
     }
 
     /// <summary>
     /// Compares two strings ignoring case.
     /// </summary>
-    /// <param name="src">source string</param>
+    /// <param name="source">source string</param>
     /// <param name="target">target string</param>
     /// <returns>True if the strings are equal, false otherwise.</returns>
     [Pure]
-    public static bool EqualsIgnoreCase(this string? src, string? target)
+    public static bool EqualsIgnoreCase(this string? source, string? target)
     {
-        return string.Equals(src, target, StringComparison.OrdinalIgnoreCase);
+        return string.Equals(source, target, StringComparison.OrdinalIgnoreCase);
     }
 
+    /// <summary>
+    /// Cuts the string to the specified length and appends "..." if it exceeds that length.
+    /// </summary>
+    /// <param name="text">source string</param>
+    /// <param name="maxLength">maximum length of the string</param>
+    /// <returns>Cut string if it exceeds the specified length, otherwise returns the original string.</returns>
     [Pure]
     [return: NotNullIfNotNull(nameof(text))]
-    public static string? Cut(this string? text, int length)
+    public static string? Cut(this string? text, int maxLength)
     {
-        if (!string.IsNullOrEmpty(text) && text.Length > length)
+        if (!string.IsNullOrEmpty(text) && text.Length > maxLength)
         {
-            text = string.Concat(text.AsSpan(0, length - 3), "...");
+            text = string.Concat(text.AsSpan(0, maxLength - 3), "...");
         }
 
         return text;


### PR DESCRIPTION
Renames `TryLeft` and `TryRight` to `TakeLeft` and `TakeRight`
respectively for clarity.
Adds `IsNullOrEmpty` extension method.
Updates documentation.
