### PR TITLE
improve memory management

### DIFF
--- a/Pacos/Services/ChatCommandHandlers/DrawHandler.cs
+++ b/Pacos/Services/ChatCommandHandlers/DrawHandler.cs
@@ -74,9 +74,10 @@ public sealed class DrawHandler
             var (replyText, generatedImageData, generatedImageMime, error) = await _imageGenerationService.GenerateImageToImageAsync(prompt, imageBytes, sourceFileMetadata.MimeType);
             if (generatedImageData != null)
             {
+                await using var generatedImageStream = new MemoryStream(generatedImageData);
                 await botClient.SendPhoto(
                     chatId: updateMessage.Chat.Id,
-                    photo: new InputFileStream(new MemoryStream(generatedImageData), "generated_image.png"),
+                    photo: new InputFileStream(generatedImageStream, "generated_image.png"),
                     caption: replyText?.Cut(Const.MaxTelegramCaptionLength),
                     replyParameters: new ReplyParameters { MessageId = updateMessage.MessageId }, // Always reply to the command message ID
                     cancellationToken: cancellationToken);
@@ -109,9 +110,10 @@ public sealed class DrawHandler
             var (replyText, generatedImageData, generatedImageMime, error) = await _imageGenerationService.GenerateTextToImageAsync(prompt);
             if (generatedImageData != null)
             {
+                await using var generatedImageStream = new MemoryStream(generatedImageData);
                 await botClient.SendPhoto(
                     chatId: updateMessage.Chat.Id,
-                    photo: new InputFileStream(new MemoryStream(generatedImageData), "generated_image.png"),
+                    photo: new InputFileStream(generatedImageStream, "generated_image.png"),
                     caption: replyText?.Cut(Const.MaxTelegramCaptionLength),
                     replyParameters: new ReplyParameters { MessageId = updateMessage.MessageId },
                     cancellationToken: cancellationToken);

--- a/Pacos/Services/ChatCommandHandlers/MentionHandler.cs
+++ b/Pacos/Services/ChatCommandHandlers/MentionHandler.cs
@@ -164,9 +164,6 @@ public sealed class MentionHandler
                 fileMetadata?.MimeType
             )).Text;
 
-            // Release potentially large media bytes from async state machine after last use
-            media.FileBytes = null;
-
             replyText = replyText.Cut(Const.MaxTelegramMessageLength);
 
             if (string.IsNullOrWhiteSpace(replyText))

--- a/Pacos/Services/ChatCommandHandlers/MentionHandler.cs
+++ b/Pacos/Services/ChatCommandHandlers/MentionHandler.cs
@@ -164,6 +164,9 @@ public sealed class MentionHandler
                 fileMetadata?.MimeType
             )).Text;
 
+            // Release potentially large media bytes from async state machine after last use
+            media.FileBytes = null;
+
             replyText = replyText.Cut(Const.MaxTelegramMessageLength);
 
             if (string.IsNullOrWhiteSpace(replyText))

--- a/Pacos/Services/TelegramMediaService.cs
+++ b/Pacos/Services/TelegramMediaService.cs
@@ -60,7 +60,7 @@ public sealed class TelegramMediaService
 
         try
         {
-            var initialCapacity = fileSize > 0 ? (int)Math.Min(fileSize.Value, maxFileSize) : 0;
+            var initialCapacity = fileSize is > 0 ? (int)Math.Min(fileSize.Value, maxFileSize) : 0;
             await using var memoryStream = initialCapacity > 0 ? new MemoryStream(initialCapacity) : new MemoryStream();
             await botClient.DownloadFile(fileInfo.FilePath, memoryStream, cancellationToken);
             var downloadedBytes = memoryStream.ToArray();

--- a/Pacos/Services/TelegramMediaService.cs
+++ b/Pacos/Services/TelegramMediaService.cs
@@ -60,7 +60,8 @@ public sealed class TelegramMediaService
 
         try
         {
-            await using var memoryStream = new MemoryStream();
+            var initialCapacity = fileSize > 0 ? (int)Math.Min(fileSize.Value, maxFileSize) : 0;
+            await using var memoryStream = initialCapacity > 0 ? new MemoryStream(initialCapacity) : new MemoryStream();
             await botClient.DownloadFile(fileInfo.FilePath, memoryStream, cancellationToken);
             var downloadedBytes = memoryStream.ToArray();
             _logger.LogInformation("Successfully downloaded media with fileId={FileId}, size={Size} bytes", fileId, downloadedBytes.Length);


### PR DESCRIPTION
This pull request improves memory management and efficiency when handling media files in the chat command and media services. The main changes focus on reusing memory streams and releasing large byte arrays after use, which helps reduce memory pressure and potential leaks.

**Memory management improvements:**

* [`Pacos/Services/ChatCommandHandlers/DrawHandler.cs`](diffhunk://#diff-013dfc483973b1e06826a882117799d36f3efd549952e9d0d1fb5a850344769bR77-R80): Replaces the creation of new `MemoryStream` instances with a single, explicitly disposed `generatedImageStream` when sending generated images, ensuring proper disposal and reducing memory usage. [[1]](diffhunk://#diff-013dfc483973b1e06826a882117799d36f3efd549952e9d0d1fb5a850344769bR77-R80) [[2]](diffhunk://#diff-013dfc483973b1e06826a882117799d36f3efd549952e9d0d1fb5a850344769bR113-R116)
* [`Pacos/Services/ChatCommandHandlers/MentionHandler.cs`](diffhunk://#diff-88f11540eac3274da11607868e35db18757a4b10d74a112896c9e64125e74ff5R167-R169): Explicitly sets `media.FileBytes` to `null` after its last use to release potentially large byte arrays from memory, preventing unnecessary retention.

**Performance optimization:**

* [`Pacos/Services/TelegramMediaService.cs`](diffhunk://#diff-56ddc6185005877ecf1b42cdae4a87238d99acbc9bc32150492d774c659c0d55L63-R64): Initializes `MemoryStream` with a calculated initial capacity based on the file size when downloading files, which can improve performance and reduce memory reallocations.